### PR TITLE
fix: codeblock pasting works now

### DIFF
--- a/packages/ckeditor5-code-block/src/converters.js
+++ b/packages/ckeditor5-code-block/src/converters.js
@@ -239,9 +239,16 @@ export function dataViewToModelCodeBlockInsertion( dataController, languageDefs 
 //
 // @param {String} stringifiedElement
 function extractDataFromCodeElement( stringifiedElement ) {
-	const data = new RegExp( /^<code[^>]*>([\S\s]*)<\/code>$/ ).exec( stringifiedElement )[ 1 ];
 
-	return data
-		.replace( /&lt;/g, '<' )
-		.replace( /&gt;/g, '>' );
+	let element = new RegExp( /^<code[^>]*>([\S\s]*)<\/code>$/ ).exec( stringifiedElement );
+
+	if(element !== null){
+		const data = new RegExp( /^<code[^>]*>([\S\s]*)<\/code>$/ ).exec( stringifiedElement )[ 1 ];
+		return data
+			.replace( /&lt;/g, '<' )
+			.replace( /&gt;/g, '>' );
+	} else {
+		return stringifiedElement.split("`").join("");
+	}
+
 }


### PR DESCRIPTION
When trying to insert markdown code like:
```
Code here
```

I was getting an error that was blocking the entire editor.

![image](https://user-images.githubusercontent.com/42647877/81292969-d0aba900-906c-11ea-8623-b7989b3d4d4e.png)

This quick fixes the error until i can find a better solution. I don't think this is the best best solution but it will do for now. 